### PR TITLE
Add edge-case regression tests; fix transaction(), where_aggregate() …

### DIFF
--- a/CustomQueryBuilder/libs/CustomQueryBuilder.php
+++ b/CustomQueryBuilder/libs/CustomQueryBuilder.php
@@ -3937,7 +3937,7 @@ class CustomQueryBuilder extends CI_DB_query_builder
         error_reporting(E_ALL);
 
         // Set error handler yang agresif
-        $old_error_handler = set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
             throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
         }, E_ALL);
 
@@ -3947,8 +3947,12 @@ class CustomQueryBuilder extends CI_DB_query_builder
         $exception = null;
 
         try {
-            // Execute callback
-            $result = call_user_func($callback);
+            // BUG FIX: pass $this through so a callback declaring the
+            // documented `function ($db) { ... }` signature (see README's
+            // Transactions section) actually receives it instead of throwing
+            // ArgumentCountError. Callbacks that ignore the parameter (e.g.
+            // via `use ($db)` closures) are unaffected.
+            $result = call_user_func($callback, $this);
         } catch (Exception $e) {
             $exception = $e;
         }
@@ -3956,11 +3960,17 @@ class CustomQueryBuilder extends CI_DB_query_builder
         // Restore error handler dan error reporting
         error_reporting($old_error_reporting);
 
-        if ($old_error_handler !== null) {
-            set_error_handler($old_error_handler);
-        } else {
-            restore_error_handler();
-        }
+        // BUG FIX: set_error_handler() always PUSHES a new handler onto PHP's
+        // internal handler stack — it never replaces the previous one in place.
+        // Calling set_error_handler($old_error_handler) here (the previous code)
+        // pushed yet another frame instead of popping back to it, leaving our
+        // aggressive handler one level further down the stack. The next
+        // *unrelated* restore_error_handler() call anywhere else in the process
+        // (e.g. PHPUnit's own per-test handler teardown) would then pop back
+        // onto our handler, silently turning ordinary deprecation notices
+        // elsewhere into thrown ErrorExceptions. restore_error_handler() is the
+        // only call that correctly pops back to whatever was active before.
+        restore_error_handler();
 
         // Handle PHP Exception yang tertangkap
         if ($exception !== null) {
@@ -4198,6 +4208,16 @@ class CustomQueryBuilder extends CI_DB_query_builder
             if (is_object($query) && method_exists($query, 'result_array')) {
                 return new CustomQueryBuilderResult($query->result_array(), null, $query);
             }
+            return $query;
+        }
+
+        // BUG FIX: a write statement (INSERT/UPDATE/DELETE) makes parent::query()
+        // return a plain bool, not a result object — with_relations pending from
+        // before this call can't apply to it (there are no rows to attach
+        // relations to). Without this check, ->result_array() below was called
+        // directly on that bool, throwing instead of just passing the bool through.
+        if (!is_object($query) || !method_exists($query, 'result_array')) {
+            $this->with_relations = [];
             return $query;
         }
 

--- a/CustomQueryBuilder/libs/RelationAggregateTrait.php
+++ b/CustomQueryBuilder/libs/RelationAggregateTrait.php
@@ -1238,6 +1238,17 @@ trait RelationAggregateTrait
             throw new InvalidArgumentException("Invalid operator: {$operator}. Allowed operators: " . implode(', ', $allowed_operators));
         }
 
+        // BUG FIX: BETWEEN/NOT BETWEEN require exactly 2 values. Without this
+        // check, process_pending_where_aggregates() indexes $value[0]/$value[1]
+        // directly — a 1-element array silently compiled to "BETWEEN 1 AND NULL"
+        // (always false, no error) and a 3+ element array silently dropped
+        // everything past the second value, instead of failing loudly.
+        if (in_array($operator, ['BETWEEN', 'NOT BETWEEN'], true)) {
+            if (!is_array($value) || count($value) !== 2) {
+                throw new InvalidArgumentException("Operator '{$operator}' requires \$value to be an array with exactly 2 elements.");
+            }
+        }
+
         // Validate column for non-count types
         if ($type !== 'count' && empty($column)) {
             throw new InvalidArgumentException("Column is required for aggregate type: {$type}");

--- a/tests/EdgeCaseTest.php
+++ b/tests/EdgeCaseTest.php
@@ -1,0 +1,457 @@
+<?php
+
+/**
+ * Edge-case coverage identified by a targeted audit of CustomQueryBuilder.php,
+ * RelationAggregateTrait.php, QueryValidationTrait.php, CustomQueryBuilderResult.php,
+ * and NestedQueryBuilder.php against the existing suite (CompiledSqlTest.php,
+ * ExecutionTest.php). Two real bugs were found and fixed alongside these tests:
+ *
+ *  - transaction() called its callback via call_user_func($callback) with NO
+ *    arguments, so the documented `function ($db) { ... }` signature (see
+ *    README's Transactions section) threw ArgumentCountError. Fixed to pass
+ *    $this through.
+ *  - where_aggregate()/or_where_aggregate() with a BETWEEN/NOT BETWEEN operator
+ *    never validated the value array's arity, so a 1-element array silently
+ *    compiled to "BETWEEN 1 AND NULL" (always false, no error) instead of
+ *    throwing. Fixed to require exactly 2 elements.
+ *
+ * Fixtures (see bootstrap.php's cqb_seed_fixtures()):
+ *   users:  1=Alice/A, 2=Bob/B, 3=Charlie/A
+ *   scores (user_id -> value): 1->10, 1->50, 1->30
+ *   category_scores (user_id, category -> value): (1,A)->100, (1,A)->50, (1,B)->999
+ *   profiles (user_id -> rank_score): 1->10, 2->30, 3->20
+ */
+class EdgeCaseTest extends CqbTestCase
+{
+    // ---------------------------------------------------------------
+    // transaction()
+    // ---------------------------------------------------------------
+
+    public function test_transaction_commits_and_passes_db_instance_to_callback()
+    {
+        // BUG FIX regression: the callback must receive the builder instance,
+        // matching the documented `function ($db) { ... }` signature.
+        $before = $this->db->count_all_results('users');
+
+        $result = $this->db->transaction(function ($db) {
+            $db->insert('users', ['name' => 'TxCommit', 'email' => 'txcommit@example.com', 'category' => 'Z']);
+            return 'callback-result';
+        });
+
+        $this->assertSame('callback-result', $result);
+        $this->assertSame($before + 1, $this->db->count_all_results('users'));
+
+        $this->db->query("DELETE FROM users WHERE email = 'txcommit@example.com'");
+    }
+
+    public function test_transaction_rolls_back_and_returns_false_on_thrown_exception()
+    {
+        $before = $this->db->count_all_results('users');
+
+        $result = $this->db->transaction(function ($db) {
+            $db->insert('users', ['name' => 'TxRollback', 'email' => 'txrollback@example.com', 'category' => 'Z']);
+            throw new Exception('deliberate failure');
+        });
+
+        $this->assertFalse($result);
+        $this->assertSame($before, $this->db->count_all_results('users'), 'Insert must be rolled back');
+    }
+
+    public function test_transaction_strict_mode_rethrows_wrapped_exception_and_still_rolls_back()
+    {
+        $before = $this->db->count_all_results('users');
+
+        try {
+            $this->db->transaction(function ($db) {
+                $db->insert('users', ['name' => 'TxStrict', 'email' => 'txstrict@example.com', 'category' => 'Z']);
+                throw new Exception('strict failure');
+            }, true);
+            $this->fail('Expected an Exception to be thrown in strict mode');
+        } catch (Exception $e) {
+            $this->assertStringContainsString('strict failure', $e->getMessage());
+        }
+
+        $this->assertSame($before, $this->db->count_all_results('users'), 'Insert must be rolled back even in strict mode');
+    }
+
+    public function test_transaction_rejects_non_callable()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->transaction('not_a_real_function');
+    }
+
+    // ---------------------------------------------------------------
+    // chunk() / chunk_by_id()
+    // ---------------------------------------------------------------
+
+    public function test_chunk_processes_all_rows_when_total_is_an_exact_multiple_of_page_size()
+    {
+        // 3 users, page_size=3 is an exact multiple: chunk() must issue one
+        // extra (empty) query after the full page rather than stopping early,
+        // but the callback itself must only fire once (for the real page).
+        $calls = 0;
+        $total = $this->db->chunk(3, function ($rows) use (&$calls) {
+            $calls++;
+        }, 'users');
+
+        $this->assertSame(3, $total);
+        $this->assertSame(1, $calls);
+    }
+
+    public function test_chunk_callback_returning_false_on_first_page_stops_immediately()
+    {
+        $calls = 0;
+        $total = $this->db->chunk(1, function ($rows) use (&$calls) {
+            $calls++;
+            return false;
+        }, 'users');
+
+        $this->assertSame(0, $total);
+        $this->assertSame(1, $calls);
+    }
+
+    public function test_chunk_by_id_accumulates_across_pages_in_id_order()
+    {
+        $seen_ids = [];
+        $total = $this->db->chunk_by_id(1, function ($rows) use (&$seen_ids) {
+            foreach ($rows as $row) {
+                $seen_ids[] = (int) $row->id;
+            }
+        }, 'id', 'users');
+
+        $this->assertSame(3, $total);
+        $this->assertSame($seen_ids, array_values(array_unique($seen_ids)), 'No row should be processed twice');
+        $sorted = $seen_ids;
+        sort($sorted);
+        $this->assertSame($sorted, $seen_ids, 'Rows must be processed in ascending id order');
+    }
+
+    public function test_chunk_by_id_throws_when_ordering_column_is_missing_from_result_row()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->select('name')->chunk_by_id(1, function ($rows) {
+            // never reached for the second page onward
+        }, 'id', 'users');
+    }
+
+    // ---------------------------------------------------------------
+    // calc_rows()
+    // ---------------------------------------------------------------
+
+    public function test_calc_rows_found_rows_ignores_limit_and_survives_eager_loading()
+    {
+        $result = $this->db->select(['id', 'name'])
+            ->with_many('scores', 'user_id', 'id')
+            ->calc_rows()
+            ->get('users', 1, 0);
+
+        $this->assertCount(1, $result->result());
+        $this->assertSame(3, $result->found_rows());
+        $this->assertIsArray($result->row()->scores);
+    }
+
+    // ---------------------------------------------------------------
+    // where_between() / where_not_between()
+    // ---------------------------------------------------------------
+
+    public function test_where_between_rejects_arrays_that_are_not_exactly_two_elements()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->where_between('id', [1])->get_compiled_select('users');
+    }
+
+    public function test_where_not_between_excludes_rows_inside_the_range()
+    {
+        $result = $this->db->select('id')->where_not_between('id', [1, 2])->get('users');
+        $this->assertSame([3], array_map('intval', array_column($result->result_array(), 'id')));
+    }
+
+    // ---------------------------------------------------------------
+    // order_by_sequence()
+    // ---------------------------------------------------------------
+
+    public function test_order_by_sequence_rejects_empty_array()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->order_by_sequence('category', []);
+    }
+
+    public function test_order_by_sequence_rejects_invalid_column_format()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->order_by_sequence('category; DROP TABLE users', ['A', 'B']);
+    }
+
+    public function test_order_by_sequence_sorts_values_absent_from_the_list_last()
+    {
+        // Alice/Charlie = 'A', Bob = 'B'. Sequence only lists 'B' first, so any
+        // row whose value ISN'T in the array falls through to the ELSE branch
+        // (index = count($array)) and must sort after every listed value.
+        $result = $this->db->select(['id', 'category'])->order_by_sequence('category', ['B'])->get('users');
+        $categories = array_column($result->result_array(), 'category');
+        $this->assertSame('B', $categories[0]);
+    }
+
+    // ---------------------------------------------------------------
+    // with() validation
+    // ---------------------------------------------------------------
+
+    public function test_with_rejects_relation_alias_that_fails_table_name_validation()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->with(['scores' => 'bad-alias!'], 'user_id', 'id')->get('users');
+    }
+
+    public function test_with_rejects_non_boolean_multiple_flag()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->with('scores', 'user_id', 'id', 'yes')->get('users');
+    }
+
+    // ---------------------------------------------------------------
+    // key_by()
+    // ---------------------------------------------------------------
+
+    public function test_key_by_last_matching_row_wins_on_duplicate_keys()
+    {
+        $result = $this->db->select(['id', 'category'])->order_by('id', 'ASC')->get('users');
+        $keyed = $result->key_by('category');
+
+        // Alice (id=1) and Charlie (id=3) both have category 'A' -> Charlie wins (last).
+        $this->assertSame(3, (int) $keyed['A']->id);
+        $this->assertCount(2, $keyed); // 'A' and 'B' only
+    }
+
+    public function test_key_by_on_empty_result_returns_empty_array()
+    {
+        $result = $this->db->where('id', 999999)->get('users');
+        $this->assertSame([], $result->key_by('id'));
+    }
+
+    public function test_key_by_closure_returning_non_scalar_key_throws()
+    {
+        $result = $this->db->get('users');
+        $this->expectException(TypeError::class);
+        $result->key_by(function ($row) {
+            return [$row->id]; // illegal array offset
+        });
+    }
+
+    // ---------------------------------------------------------------
+    // CustomQueryBuilderResult direct-call edge cases
+    // ---------------------------------------------------------------
+
+    public function test_result_call_to_undefined_method_throws_bad_method_call_exception()
+    {
+        $result = $this->db->get('users');
+        $this->expectException(BadMethodCallException::class);
+        $result->this_method_does_not_exist_anywhere();
+    }
+
+    public function test_result_value_on_wrapper_returns_null_for_missing_property()
+    {
+        $result = $this->db->select('id')->where('id', 1)->get('users');
+        $this->assertNull($result->value('no_such_column'));
+    }
+
+    // ---------------------------------------------------------------
+    // where_exists() / search() / unless() / where_has() shorthand
+    // ---------------------------------------------------------------
+
+    public function test_where_exists_rejects_non_callable_callback()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->from('users')->where_exists('not-a-callback');
+    }
+
+    public function test_where_exists_callback_exception_does_not_corrupt_outer_builder_state()
+    {
+        try {
+            $this->db->from('users')->where_exists(function ($q) {
+                throw new RuntimeException('boom inside subquery callback');
+            });
+            $this->fail('Expected the callback exception to propagate');
+        } catch (RuntimeException $e) {
+            $this->assertSame('boom inside subquery callback', $e->getMessage());
+        }
+
+        // The outer builder must still be usable for an unrelated query.
+        $this->db->reset_query();
+        $result = $this->db->where('id', 1)->get('users');
+        $this->assertSame(1, $result->num_rows());
+    }
+
+    public function test_sibling_where_exists_calls_do_not_leak_state_between_each_other()
+    {
+        $sql = $this->sql($this->db->from('users')
+            ->where_exists(function ($q) {
+                $q->select('1')->from('scores')->where('scores.user_id = users.id');
+            })
+            ->where_exists(function ($q) {
+                $q->select('1')->from('profiles')->where('profiles.user_id = users.id');
+            })
+            ->get_compiled_select());
+
+        $this->assertSame(
+            'SELECT * FROM `users` WHERE EXISTS (SELECT 1 FROM `scores` WHERE `scores`.`user_id` = `users`.`id`) AND EXISTS (SELECT 1 FROM `profiles` WHERE `profiles`.`user_id` = `users`.`id`)',
+            $sql
+        );
+    }
+
+    public function test_search_with_empty_columns_array_leaves_query_unchanged()
+    {
+        $sql = $this->sql($this->db->search('john', [])->get_compiled_select('users'));
+        $this->assertSame('SELECT * FROM `users`', $sql);
+    }
+
+    public function test_search_skips_blank_entries_in_columns_without_producing_invalid_sql()
+    {
+        // Regression guard: an empty-string column at index 0 must not leave a
+        // dangling "OR" as the first condition inside the group.
+        $sql = $this->sql($this->db->search('john', ['', 'name'])->get_compiled_select('users'));
+        $this->assertSame("SELECT * FROM `users` WHERE ( `name` LIKE '%john%' ESCAPE '!' )", $sql);
+    }
+
+    public function test_unless_runs_default_callback_when_condition_is_true()
+    {
+        $sql = $this->sql($this->db->unless(true, function ($q) {
+            $q->where('category', 'A');
+        }, function ($q) {
+            $q->where('category', 'B');
+        })->get_compiled_select('users'));
+
+        $this->assertSame("SELECT * FROM `users` WHERE `category` = 'B'", $sql);
+    }
+
+    public function test_where_has_shorthand_operator_without_explicit_count_defaults_to_one()
+    {
+        // BUG FIX regression (see bug-fix comment above where_has()): the
+        // shorthand where_has($rel, $fk, $lk, '>') used to pick up the old
+        // $operator default '>=' as the count instead of defaulting to 1.
+        $result = $this->db->where_has('scores', 'user_id', 'id', '>=')->get('users');
+        $this->assertSame(['Alice'], array_column($result->result_array(), 'name'));
+    }
+
+    // ---------------------------------------------------------------
+    // query() with pending relations / non-SELECT statements
+    // ---------------------------------------------------------------
+
+    public function test_query_with_non_select_statement_still_returns_plain_bool_when_relations_pending()
+    {
+        $this->db->with_many('scores', 'user_id', 'id');
+        $ok = $this->db->query("UPDATE users SET category = category WHERE id = 1");
+        $this->assertIsBool($ok);
+        $this->db->reset_query();
+    }
+
+    // ---------------------------------------------------------------
+    // RelationAggregateTrait: where_aggregate()
+    // ---------------------------------------------------------------
+
+    public function test_where_aggregate_rejects_an_alias_that_was_never_registered()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->where_aggregate('never_defined_alias >', 100)->get_compiled_select('users');
+    }
+
+    public function test_where_aggregate_between_rejects_a_one_element_array()
+    {
+        // BUG FIX regression: previously silently compiled to
+        // "BETWEEN 1 AND NULL" (always false) instead of throwing.
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->with_calculation(['scores' => 'score_total'], 'user_id', 'id', 'SUM(value)')
+            ->where_aggregate('score_total BETWEEN', [1])
+            ->get_compiled_select('users');
+    }
+
+    public function test_where_aggregate_between_rejects_a_three_element_array()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->with_calculation(['scores' => 'score_total'], 'user_id', 'id', 'SUM(value)')
+            ->where_aggregate('score_total BETWEEN', [1, 2, 3])
+            ->get_compiled_select('users');
+    }
+
+    public function test_where_aggregate_coalesces_null_to_zero_for_non_between_operators()
+    {
+        // Bob has zero rows in `scores`; without COALESCE, SUM(...) is NULL and
+        // `NULL != 0` is NULL (never true), which would wrongly exclude him.
+        $result = $this->db->select(['id', 'name'])
+            ->with_sum(['scores' => 'total'], 'user_id', 'id', 'value')
+            ->where_aggregate('total =', 0)
+            ->get('users');
+
+        $this->assertContains('Bob', array_column($result->result_array(), 'name'));
+    }
+
+    // ---------------------------------------------------------------
+    // RelationAggregateTrait: join_*
+    // ---------------------------------------------------------------
+
+    public function test_join_sum_requires_a_column()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->join_sum('scores', 'user_id', 'id', null)->get_compiled_select('users');
+    }
+
+    public function test_join_sum_rejects_invalid_column_name()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->join_sum('scores', 'user_id', 'id', 'value; DROP TABLE users')->get_compiled_select('users');
+    }
+
+    public function test_join_calculation_rejects_a_dangerous_expression()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->join_calculation('scores', 'user_id', 'id', 'SUM(value) UNION SELECT 1')->get_compiled_select('users');
+    }
+
+    // ---------------------------------------------------------------
+    // RelationAggregateTrait: with_calculation() expression validation
+    // ---------------------------------------------------------------
+
+    public function test_with_calculation_rejects_unbalanced_parentheses()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->with_calculation(['scores' => 'x'], 'user_id', 'id', 'SUM(value')->get_compiled_select('users');
+    }
+
+    public function test_with_calculation_rejects_dangerous_keyword()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->with_calculation(['scores' => 'x'], 'user_id', 'id', 'SUM(value) UNION SELECT 1')->get_compiled_select('users');
+    }
+
+    public function test_with_calculation_rejects_expression_over_length_limit()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->with_calculation(['scores' => 'x'], 'user_id', 'id', str_repeat('a', 2001))->get_compiled_select('users');
+    }
+
+    public function test_with_avg_rejects_lowercase_disallowed_function_name()
+    {
+        // Case-insensitive WAF-bypass guard: is_allowed_sql_function() upper-cases
+        // before checking the allow-list, so a lowercase "sleep(0)" must be
+        // rejected exactly like the already-covered backtick-quoted `SLEEP`(0).
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->with_avg(['scores' => 'x'], 'user_id', 'id', 'sleep(0)', true)->get_compiled_select('users');
+    }
+
+    // ---------------------------------------------------------------
+    // QueryValidationTrait: identifier length boundary
+    // ---------------------------------------------------------------
+
+    public function test_column_name_of_exactly_64_chars_is_accepted()
+    {
+        $column = str_repeat('a', 64);
+        // Should not throw — 64 is the documented maximum, not the cutoff.
+        $sql = $this->sql($this->db->where_in($column, [1])->get_compiled_select('users'));
+        $this->assertStringContainsString('`' . $column . '`', $sql);
+    }
+
+    public function test_column_name_of_65_chars_is_rejected()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->db->where_in(str_repeat('a', 65), [1])->get_compiled_select('users');
+    }
+}


### PR DESCRIPTION
…BETWEEN, and query() bugs found along the way

Audited CustomQueryBuilder.php, RelationAggregateTrait.php, QueryValidationTrait.php, CustomQueryBuilderResult.php, and NestedQueryBuilder.php against the existing PHPUnit suite to find untested edge cases, then added 42 new tests covering transaction(), chunk()/chunk_by_id() boundaries, calc_rows() with eager loading, where_between(), order_by_sequence(), with() validation, key_by() edge cases, where_exists() isolation, search()/unless()/where_has() shorthand, query() with pending relations, where_aggregate() validation, join_*() validation, with_calculation() expression limits, and identifier length boundaries.

Actually running transaction() (previously untested) surfaced three real bugs, now fixed:
- transaction() called its callback with call_user_func($callback) — no arguments — so the documented `function ($db) { ... }` signature threw ArgumentCountError. Now passes $this through.
- transaction()'s error-handler cleanup called set_error_handler($old_error_handler) instead of restore_error_handler(). set_error_handler() always pushes a new stack frame rather than replacing the previous one, so this left an extra frame behind every call; an unrelated restore_error_handler() elsewhere in the process (e.g. PHPUnit's own per-test teardown) could later pop back onto transaction()'s aggressive handler, turning ordinary deprecation notices into thrown ErrorExceptions.
- query() with pending with_relations crashed when the SQL was a write statement (INSERT/UPDATE/DELETE): parent::query() returns a plain bool for those, but the code unconditionally called ->result_array() on it.

Also hardened where_aggregate()/or_where_aggregate(): BETWEEN/NOT BETWEEN now require the value to be an array of exactly 2 elements. Previously a 1-element array silently compiled to "... BETWEEN 1 AND NULL" (always false, no error).